### PR TITLE
Add two aliases to start and stop containers

### DIFF
--- a/src/m2-warden-aliases.sh
+++ b/src/m2-warden-aliases.sh
@@ -4,6 +4,18 @@
 # @author: Raj KB <magepsycho@gmail.com>
 ################################################################################
 
+# Create and start containers
+wardenEnvUp() {
+	warden env up
+}
+alias wup="wardenEnvUp"
+
+# Stop services
+wardenEnvStop() {
+	warden env stop
+}
+alias wst="wardenEnvStop"
+
 # Connects to `php-debug` container shell
 wardenDebug() {
 	warden debug


### PR DESCRIPTION
This PR adds the `wup` and `wst` aliases to respectively starting and stopping containers.